### PR TITLE
Add `NetworkPolicy` to allow CCM communication to runtime

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -26,6 +26,7 @@ spec:
         role: cloud-controller-manager
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.resources.gardener.cloud/to-kube-apiserver-tcp-443: allowed
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}


### PR DESCRIPTION
# Proposed Changes

- allow CCM to communicate with runtime cluster apiserver

Fixes:
```
2024-08-20T13:04:46.938287056Z I0820 13:04:46.937901       1 log.go:245] Failed to setup field indexer for server claims: failed to get restmapping: failed to get server groups: Get "https://<runtime-apiserver>:6443/api": dial tcp <runtime-apiserver-ip>:6443: connect: connection refused
```