### PR TITLE
Bump `github.com/gardener/gardener@v1.99.4`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.61

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.2 AS builder
 
 ARG GOARCH=''
 

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/ironcore-dev/gardener-extension-provider-metal
 
-go 1.22.2
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/gardener/etcd-druid v0.22.5
-	github.com/gardener/gardener v1.99.1
+	github.com/gardener/gardener v1.99.4
 	github.com/gardener/machine-controller-manager v0.53.1
 	github.com/go-logr/logr v1.4.2
 	github.com/ironcore-dev/controller-utils v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/gardener/cert-management v0.15.0 h1:ohm1eWae2rQSkwFGWXTt+lBv4rLBhtJsJ
 github.com/gardener/cert-management v0.15.0/go.mod h1:3BK2VEtGwv2ijf3bSziTLMCUvYnPzIQrQ/uPeZzL4m0=
 github.com/gardener/etcd-druid v0.22.5 h1:1k7oEB796ZYiAz6XzQFfG7NevRtLonnXE/p4LudeWdw=
 github.com/gardener/etcd-druid v0.22.5/go.mod h1:FROhfVKyWBo4krlPe3R6FIhJRmOmijEWBdEeUP0CJjE=
-github.com/gardener/gardener v1.99.1 h1:c/wVXYgt4j7eHCMwxpQPPpaLXt1BY/IPYStfCtNsR8Q=
-github.com/gardener/gardener v1.99.1/go.mod h1:XboPwJptOg9ZfXTjuohGk7X8kxnF0o88gJnz6Ed7Vqc=
+github.com/gardener/gardener v1.99.4 h1:LhNE4oON/8Viv3DXjACQLW3Nddo+ZpfQdPpBHHdJVBI=
+github.com/gardener/gardener v1.99.4/go.mod h1:XboPwJptOg9ZfXTjuohGk7X8kxnF0o88gJnz6Ed7Vqc=
 github.com/gardener/hvpa-controller/api v0.15.0 h1:igsalL5Z6kFMn1+Kv1Eq0cRjYW+4oBA1aEY/yDO2QtI=
 github.com/gardener/hvpa-controller/api v0.15.0/go.mod h1:fqb4wNrQLESDKpm7ppXyCM2Gvx96wRlLL35aH0ge07U=
 github.com/gardener/machine-controller-manager v0.53.1 h1:4P9qtzoD+989Lhc8XaI6Zo3X2TaQVXgHHrbEpuhJcrI=


### PR DESCRIPTION
# Proposed Changes

- Bump `golang` to 1.23.0
- Bump golangci-lint to 1.61 in GH workflow