### PR TITLE
Add annotation to mark seeds containing a metal-api shoot to fix NetworkPolicies

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -276,6 +276,14 @@ func getCCMChartValues(
 		return nil, fmt.Errorf("secret %q not found", cloudControllerManagerServerName)
 	}
 
+	podLabels := map[string]any{
+		v1beta1constants.LabelPodMaintenanceRestart: "true",
+	}
+	localAPI, ok := cluster.Seed.Annotations[metal.LocalMetalAPIAnnotation]
+	if ok && localAPI == "true" {
+		podLabels[metal.AllowEgressToIstioIngressLabel] = "allowed"
+	}
+
 	values := map[string]any{
 		"enabled":     true,
 		"replicas":    extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
@@ -284,9 +292,7 @@ func getCCMChartValues(
 		"podAnnotations": map[string]any{
 			"checksum/secret-" + internal.CloudProviderConfigMapName: checksums[internal.CloudProviderConfigMapName],
 		},
-		"podLabels": map[string]any{
-			v1beta1constants.LabelPodMaintenanceRestart: "true",
-		},
+		"podLabels":       podLabels,
 		"tlsCipherSuites": kutil.TLSCipherSuites,
 		"secrets": map[string]any{
 			"server": serverSecret.Name,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -166,6 +166,7 @@ var _ = Describe("Valueprovider Reconcile", func() {
 						},
 					},
 				},
+				Seed: &gardencorev1beta1.Seed{},
 			}
 
 			checksums := map[string]string{

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -19,14 +19,20 @@ func (w *workerDelegate) GetMachineControllerManagerChartValues(ctx context.Cont
 		return nil, err
 	}
 
+	podLabels := map[string]any{
+		v1beta1constants.LabelPodMaintenanceRestart: "true",
+	}
+	localAPI, ok := w.cluster.Seed.Annotations[metal.LocalMetalAPIAnnotation]
+	if ok && localAPI == "true" {
+		podLabels[metal.AllowEgressToIstioIngressLabel] = "allowed"
+	}
+
 	return map[string]any{
 		"providerName": metal.ProviderName,
 		"namespace": map[string]any{
 			"uid": namespace.UID,
 		},
-		"podLabels": map[string]any{
-			v1beta1constants.LabelPodMaintenanceRestart: "true",
-		},
+		"podLabels": podLabels,
 	}, nil
 }
 

--- a/pkg/metal/types.go
+++ b/pkg/metal/types.go
@@ -47,6 +47,10 @@ const (
 	IgnitionOverrideFieldName = "ignitionOverride"
 	// ClusterNameLabel is the name is the label key of the cluster name
 	ClusterNameLabel = "extension.metal.dev/cluster-name"
+	// LocalMetalAPIAnnotation is the name of the annotation to mark a seed, which contains a local metal API shoot
+	LocalMetalAPIAnnotation = "metal.ironcore.dev/local-metal-api"
+	// AllowEgressToIstioIngressLabel is the label key to allow egress to the istio ingress gateway
+	AllowEgressToIstioIngressLabel = "networking.resources.gardener.cloud/to-all-istio-ingresses-istio-ingressgateway-tcp-9443"
 
 	// CloudProviderConfigName is the name of the secret containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"


### PR DESCRIPTION
NetworkPolicy are setup by Gardener, so that controllers for shoots cannot reach the apiservers of other shoots. In cases where a shoot is providing the metal-api, it cannot be reached by default due to that setup.

# Proposed Changes

- Add annotation to mark seeds that host a local shoot, which server the metal-api for other shoots