### PR TITLE
Lookup ignition secret in garden cluster

### DIFF
--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -69,6 +69,7 @@ func (d *delegateFactory) WorkerDelegate(_ context.Context, worker *extensionsv1
 		serverVersion.GitVersion,
 		worker,
 		cluster,
+		d.gardenReader,
 	)
 }
 
@@ -81,6 +82,7 @@ type workerDelegate struct {
 	cloudProfileConfig *api.CloudProfileConfig
 	cluster            *extensionscontroller.Cluster
 	worker             *extensionsv1alpha1.Worker
+	gardenReader       client.Reader
 }
 
 // NewWorkerDelegate creates a new context for a worker reconciliation.
@@ -91,6 +93,7 @@ func NewWorkerDelegate(
 	serverVersion string,
 	worker *extensionsv1alpha1.Worker,
 	cluster *extensionscontroller.Cluster,
+	gardenReader client.Reader,
 ) (
 	genericactuator.WorkerDelegate,
 	error,
@@ -108,5 +111,6 @@ func NewWorkerDelegate(
 		cloudProfileConfig: config,
 		cluster:            cluster,
 		worker:             worker,
+		gardenReader:       gardenReader,
 	}, nil
 }

--- a/pkg/controller/worker/machine_images_test.go
+++ b/pkg/controller/worker/machine_images_test.go
@@ -34,7 +34,7 @@ var _ = Describe("MachinesImages", func() {
 
 		By("creating a worker delegate")
 		decoder := serializer.NewCodecFactory(k8sClient.Scheme(), serializer.EnableStrict).UniversalDecoder()
-		workerDelegate, err := NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, testCluster)
+		workerDelegate, err := NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, testCluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("calling the updating machine image status")

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Machines", func() {
 			}
 			By("deploying the machine class for a given multi zone cluster")
 			decoder := serializer.NewCodecFactory(k8sClient.Scheme(), serializer.EnableStrict).UniversalDecoder()
-			workerDelegate, err = NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, testCluster)
+			workerDelegate, err = NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, testCluster, k8sClient)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -134,7 +134,7 @@ var _ = Describe("Machines", func() {
 			className2      = fmt.Sprintf("%s-%s", deploymentName2, workerPoolHash)
 		)
 		decoder := serializer.NewCodecFactory(k8sClient.Scheme(), serializer.EnableStrict).UniversalDecoder()
-		workerDelegate, err := NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, testCluster)
+		workerDelegate, err := NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, testCluster, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("generating the machine deployments")


### PR DESCRIPTION
# Proposed Changes

- Lookup ignition secret in garden cluster. I'm passing through the `gardenReader`, which is used to retrieve the `CloudProfile`.

Fixes #128.