### PR TITLE
Add `NodeNamePolicy` to `Controlplane` configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/ironcore-dev/gardener-extension-provider-ironcore-metal
 
 go 1.24.0
 
-toolchain go1.24.3
-
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -144,6 +144,19 @@ LoadBalancerConfig
 <p>LoadBalancerConfig contains configuration settings for the shoot loadbalancing.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>hostnamePolicy</code></br>
+<em>
+<a href="#ironcore-metal.provider.extensions.gardener.cloud/v1alpha1.HostnamePolicy">
+HostnamePolicy
+</a>
+</em>
+</td>
+<td>
+<p>HostnamePolicy is a policy for generating hostnames for the worker nodes.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ironcore-metal.provider.extensions.gardener.cloud/v1alpha1.BGPFilter">BGPFilter
@@ -542,6 +555,15 @@ IPAMKind
 </tr>
 </tbody>
 </table>
+<h3 id="ironcore-metal.provider.extensions.gardener.cloud/v1alpha1.HostnamePolicy">HostnamePolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ironcore-metal.provider.extensions.gardener.cloud/v1alpha1.ControlPlaneConfig">ControlPlaneConfig</a>)
+</p>
+<p>
+<p>HostnamePolicy is a policy for generating hostnames for the worker nodes.</p>
+</p>
 <h3 id="ironcore-metal.provider.extensions.gardener.cloud/v1alpha1.IPAMConfig">IPAMConfig
 </h3>
 <p>

--- a/pkg/apis/metal/types_controlplane.go
+++ b/pkg/apis/metal/types_controlplane.go
@@ -19,7 +19,18 @@ type ControlPlaneConfig struct {
 
 	// LoadBalancerConfig contains configuration settings for the shoot loadbalancing.
 	LoadBalancerConfig *LoadBalancerConfig
+
+	// HostnamePolicy is a policy for generating hostnames for the worker nodes.
+	HostnamePolicy HostnamePolicy
 }
+
+// HostnamePolicy is a policy for generating hostnames for the worker nodes.
+type HostnamePolicy string
+
+const (
+	// HostnamePolicyServer is a policy for generating hostnames based on the Server.
+	HostnamePolicyServer HostnamePolicy = "Server"
+)
 
 // CloudControllerNetworking contains configuration settings for CCM networking.
 type CloudControllerNetworking struct {
@@ -102,7 +113,7 @@ type BgpPeer struct {
 	// NodeSelector is a key-value pair to select nodes that should have this peering.
 	NodeSelector string
 
-	// Filters contains the filters for the BGP peer.
+	// Filters contain the filters for the BGP peer.
 	Filters []string
 }
 

--- a/pkg/apis/metal/types_controlplane.go
+++ b/pkg/apis/metal/types_controlplane.go
@@ -21,15 +21,15 @@ type ControlPlaneConfig struct {
 	LoadBalancerConfig *LoadBalancerConfig
 
 	// HostnamePolicy is a policy for generating hostnames for the worker nodes.
-	HostnamePolicy HostnamePolicy
+	HostnamePolicy NodeNamePolicy
 }
 
-// HostnamePolicy is a policy for generating hostnames for the worker nodes.
-type HostnamePolicy string
+// NodeNamePolicy is a policy for generating hostnames for the worker nodes.
+type NodeNamePolicy string
 
 const (
-	// HostnamePolicyServer is a policy for generating hostnames based on the Server.
-	HostnamePolicyServer HostnamePolicy = "Server"
+	// NodeNamePolicyServerName is a policy for generating hostnames based on the Server.
+	NodeNamePolicyServerName NodeNamePolicy = "ServerName"
 )
 
 // CloudControllerNetworking contains configuration settings for CCM networking.

--- a/pkg/apis/metal/v1alpha1/types_controlplane.go
+++ b/pkg/apis/metal/v1alpha1/types_controlplane.go
@@ -21,7 +21,18 @@ type ControlPlaneConfig struct {
 	// LoadBalancerConfig contains configuration settings for the shoot loadbalancing.
 	// +optional
 	LoadBalancerConfig *LoadBalancerConfig `json:"loadBalancerConfig,omitempty"`
+
+	// HostnamePolicy is a policy for generating hostnames for the worker nodes.
+	HostnamePolicy HostnamePolicy `json:"hostnamePolicy,omitempty"`
 }
+
+// HostnamePolicy is a policy for generating hostnames for the worker nodes.
+type HostnamePolicy string
+
+const (
+	// HostnamePolicyServer is a policy for generating hostnames based on the Server.
+	HostnamePolicyServer HostnamePolicy = "Server"
+)
 
 // CloudControllerNetworking contains configuration settings for CCM networking.
 type CloudControllerNetworking struct {

--- a/pkg/apis/metal/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/metal/v1alpha1/zz_generated.conversion.go
@@ -448,7 +448,7 @@ func Convert_metal_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in *metal.C
 func autoConvert_v1alpha1_ControlPlaneConfig_To_metal_ControlPlaneConfig(in *ControlPlaneConfig, out *metal.ControlPlaneConfig, s conversion.Scope) error {
 	out.CloudControllerManager = (*metal.CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	out.LoadBalancerConfig = (*metal.LoadBalancerConfig)(unsafe.Pointer(in.LoadBalancerConfig))
-	out.HostnamePolicy = metal.HostnamePolicy(in.HostnamePolicy)
+	out.HostnamePolicy = metal.NodeNamePolicy(in.HostnamePolicy)
 	return nil
 }
 

--- a/pkg/apis/metal/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/metal/v1alpha1/zz_generated.conversion.go
@@ -448,6 +448,7 @@ func Convert_metal_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in *metal.C
 func autoConvert_v1alpha1_ControlPlaneConfig_To_metal_ControlPlaneConfig(in *ControlPlaneConfig, out *metal.ControlPlaneConfig, s conversion.Scope) error {
 	out.CloudControllerManager = (*metal.CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	out.LoadBalancerConfig = (*metal.LoadBalancerConfig)(unsafe.Pointer(in.LoadBalancerConfig))
+	out.HostnamePolicy = metal.HostnamePolicy(in.HostnamePolicy)
 	return nil
 }
 
@@ -459,6 +460,7 @@ func Convert_v1alpha1_ControlPlaneConfig_To_metal_ControlPlaneConfig(in *Control
 func autoConvert_metal_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *metal.ControlPlaneConfig, out *ControlPlaneConfig, s conversion.Scope) error {
 	out.CloudControllerManager = (*CloudControllerManagerConfig)(unsafe.Pointer(in.CloudControllerManager))
 	out.LoadBalancerConfig = (*LoadBalancerConfig)(unsafe.Pointer(in.LoadBalancerConfig))
+	out.HostnamePolicy = HostnamePolicy(in.HostnamePolicy)
 	return nil
 }
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/charts"
-	apismetal "github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/apis/metal"
+	metalapi "github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/apis/metal"
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/internal"
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/metal"
 )
@@ -170,7 +170,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]any, error) {
-	cpConfig := &apismetal.ControlPlaneConfig{}
+	cpConfig := &metalapi.ControlPlaneConfig{}
 	if cp.Spec.ProviderConfig != nil {
 		if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
 			return nil, fmt.Errorf("could not decode providerConfig of controlplane '%s': %w", client.ObjectKeyFromObject(cp), err)
@@ -191,7 +191,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	map[string]any,
 	error,
 ) {
-	cpConfig := &apismetal.ControlPlaneConfig{}
+	cpConfig := &metalapi.ControlPlaneConfig{}
 	if cp.Spec.ProviderConfig != nil {
 		if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
 			return nil, fmt.Errorf("could not decode providerConfig of controlplane '%s': %w", client.ObjectKeyFromObject(cp), err)
@@ -212,7 +212,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	map[string]any,
 	error,
 ) {
-	cpConfig := &apismetal.ControlPlaneConfig{}
+	cpConfig := &metalapi.ControlPlaneConfig{}
 	if cp.Spec.ProviderConfig != nil {
 		if _, _, err := vp.decoder.Decode(cp.Spec.ProviderConfig.Raw, nil, cpConfig); err != nil {
 			return nil, fmt.Errorf("could not decode providerConfig of controlplane '%s': %w", client.ObjectKeyFromObject(cp), err)
@@ -243,7 +243,7 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 
 // getControlPlaneChartValues collects and returns the control plane chart values.
 func getControlPlaneChartValues(
-	cpConfig *apismetal.ControlPlaneConfig,
+	cpConfig *metalapi.ControlPlaneConfig,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	secretsReader secretsmanager.Reader,
@@ -268,7 +268,7 @@ func getControlPlaneChartValues(
 
 // getCCMChartValues collects and returns the CCM chart values.
 func getCCMChartValues(
-	cpConfig *apismetal.ControlPlaneConfig,
+	cpConfig *metalapi.ControlPlaneConfig,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	secretsReader secretsmanager.Reader,
@@ -344,7 +344,7 @@ func isOverlayEnabled(networking *gardencorev1beta1.Networking) (bool, error) {
 }
 
 // getControlPlaneShootChartValues collects and returns the control plane shoot chart values.
-func (vp *valuesProvider) getControlPlaneShootChartValues(cluster *extensionscontroller.Cluster, cp *apismetal.ControlPlaneConfig) (map[string]any, error) {
+func (vp *valuesProvider) getControlPlaneShootChartValues(cluster *extensionscontroller.Cluster, cp *metalapi.ControlPlaneConfig) (map[string]any, error) {
 	if cluster.Shoot == nil {
 		return nil, fmt.Errorf("cluster %s does not contain a shoot object", cluster.ObjectMeta.Name)
 	}
@@ -367,7 +367,7 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(cluster *extensionscon
 }
 
 // getConfigChartValues collects and returns the config chart values.
-func (vp *valuesProvider) getConfigChartValues(cluster *extensionscontroller.Cluster, cpConfig *apismetal.ControlPlaneConfig) (map[string]any, error) {
+func (vp *valuesProvider) getConfigChartValues(cluster *extensionscontroller.Cluster, cpConfig *metalapi.ControlPlaneConfig) (map[string]any, error) {
 	values := map[string]any{
 		metal.ClusterFieldName: cluster.ObjectMeta.Name,
 	}
@@ -393,7 +393,7 @@ func (vp *valuesProvider) getConfigChartValues(cluster *extensionscontroller.Clu
 
 // getMetallbChartValues collects and returns the MetalLB chart values.
 func getMetallbChartValues(
-	cpConfig *apismetal.ControlPlaneConfig,
+	cpConfig *metalapi.ControlPlaneConfig,
 ) (map[string]any, error) {
 	if cpConfig.LoadBalancerConfig == nil || cpConfig.LoadBalancerConfig.MetallbConfig == nil {
 		return map[string]any{
@@ -421,7 +421,7 @@ func getMetallbChartValues(
 
 // getCalicoBgpChartValues collects and returns the Calico BGP chart values.
 func getCalicoBgpChartValues(
-	cpConfig *apismetal.ControlPlaneConfig,
+	cpConfig *metalapi.ControlPlaneConfig,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]any, error) {
 	if cpConfig.LoadBalancerConfig == nil || cpConfig.LoadBalancerConfig.CalicoBgpConfig == nil {
@@ -549,7 +549,7 @@ func getCalicoBgpChartValues(
 	}, nil
 }
 
-func processFilters(filtersConfig []apismetal.BGPFilterRule) ([]map[string]any, error) {
+func processFilters(filtersConfig []metalapi.BGPFilterRule) ([]map[string]any, error) {
 	var filters []map[string]any
 	for _, filter := range filtersConfig {
 		if err := parseAddressPool(filter.CIDR); err != nil {

--- a/pkg/webhook/controlplane/add.go
+++ b/pkg/webhook/controlplane/add.go
@@ -20,8 +20,6 @@ import (
 
 var (
 	logger = log.Log.WithName("metal-controlplane-webhook")
-	// GardenletManagesMCM specifies whether the machine-controller-manager should be managed.
-	GardenletManagesMCM bool
 )
 
 // AddToManager creates a webhook and adds it to the manager.
@@ -36,7 +34,7 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			{Obj: &vpaautoscalingv1.VerticalPodAutoscaler{}},
 			{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
 		},
-		Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger, GardenletManagesMCM), oscutils.NewUnitSerializer(),
+		Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger, mgr.GetScheme()), oscutils.NewUnitSerializer(),
 			kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
 	})
 }

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -17,23 +17,29 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/imagevector"
+	metalapi "github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/apis/metal"
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/metal"
 )
 
 // NewEnsurer creates a new controlplane ensurer.
-func NewEnsurer(logger logr.Logger, gardenletManagesMCM bool) genericmutator.Ensurer {
+func NewEnsurer(logger logr.Logger, scheme *runtime.Scheme) genericmutator.Ensurer {
 	return &ensurer{
-		logger: logger.WithName("metal-controlplane-ensurer"),
+		logger:  logger.WithName("ironcore-metal-controlplane-ensurer"),
+		decoder: serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder(),
 	}
 }
 
 type ensurer struct {
 	genericmutator.NoopEnsurer
-	logger logr.Logger
+	logger  logr.Logger
+	decoder runtime.Decoder
 }
 
 // ImageVector is exposed for testing.
@@ -50,6 +56,14 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 		return fmt.Errorf("failed to get cluster: %w", err)
 	}
 
+	cpConfig := &metalapi.ControlPlaneConfig{}
+	if cluster.Shoot != nil && cluster.Shoot.Spec.Provider.ControlPlaneConfig != nil {
+		cp := cluster.Shoot.Spec.Provider.ControlPlaneConfig
+		if _, _, err := e.decoder.Decode(cp.Raw, nil, cpConfig); err != nil {
+			return fmt.Errorf("could not decode providerConfig of controlplane for cluster %s: %w", client.ObjectKeyFromObject(cluster.Shoot), err)
+		}
+	}
+
 	template := &newObj.Spec.Template
 	ps := &template.Spec
 
@@ -64,7 +78,7 @@ func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, 
 	)
 
 	if c := extensionswebhook.ContainerWithName(ps.Containers, metal.MachineControllerManagerProviderIroncoreImageName); c != nil {
-		ensureMCMCommandLineArgs(c)
+		ensureMCMCommandLineArgs(c, cpConfig)
 		c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, corev1.VolumeMount{
 			Name:      "cloudprovider",
 			MountPath: "/etc/metal",
@@ -131,8 +145,11 @@ func (e *ensurer) EnsureClusterAutoscalerDeployment(_ context.Context, _ extensi
 	return nil
 }
 
-func ensureMCMCommandLineArgs(c *corev1.Container) {
+func ensureMCMCommandLineArgs(c *corev1.Container, cp *metalapi.ControlPlaneConfig) {
 	c.Args = extensionswebhook.EnsureStringWithPrefix(c.Args, "--metal-kubeconfig=", "/etc/metal/kubeconfig")
+	if cp.HostnamePolicy == metalapi.HostnamePolicyServer {
+		c.Args = extensionswebhook.EnsureStringWithPrefix(c.Args, "--use-server-name-as-node-name=", "true")
+	}
 }
 
 func ensureKubeAPIServerCommandLineArgs(c *corev1.Container) {

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -147,8 +147,8 @@ func (e *ensurer) EnsureClusterAutoscalerDeployment(_ context.Context, _ extensi
 
 func ensureMCMCommandLineArgs(c *corev1.Container, cp *metalapi.ControlPlaneConfig) {
 	c.Args = extensionswebhook.EnsureStringWithPrefix(c.Args, "--metal-kubeconfig=", "/etc/metal/kubeconfig")
-	if cp.HostnamePolicy == metalapi.HostnamePolicyServer {
-		c.Args = extensionswebhook.EnsureStringWithPrefix(c.Args, "--use-server-name-as-node-name=", "true")
+	if cp.HostnamePolicy == metalapi.NodeNamePolicyServerName {
+		c.Args = extensionswebhook.EnsureStringWithPrefix(c.Args, "--node-name-policy=", string(metalapi.NodeNamePolicyServerName))
 	}
 }
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Ensurer", func() {
 				APIVersion: v1alpha1.SchemeGroupVersion.String(),
 				Kind:       "ControlPlaneConfig",
 			},
-			HostnamePolicy: apismetal.HostnamePolicyServer,
+			HostnamePolicy: apismetal.NodeNamePolicyServerName,
 		}
 		controlPlaneConfigRaw, _  = json.Marshal(controlPlaneConfig)
 		eContextK8sServerHostName = gcontext.NewInternalGardenContext(
@@ -358,7 +358,7 @@ var _ = Describe("Ensurer", func() {
 			Expect(ensurer.EnsureMachineControllerManagerDeployment(ctx, eContextK8sServerHostName, deployment, nil)).To(Succeed())
 			Expect(deployment.Spec.Template.Spec.Containers).To(
 				ContainElement(
-					HaveField("Args", ContainElement("--use-server-name-as-node-name=true")),
+					HaveField("Args", ContainElement("--node-name-policy=ServerName")),
 				),
 			)
 		})

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and IronCore contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package controlplane
+package controlplane_test
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -19,16 +20,22 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	apismetal "github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/apis/metal"
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/apis/metal/v1alpha1"
 	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/metal"
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/webhook/controlplane"
 )
 
 const (
@@ -46,8 +53,7 @@ var _ = Describe("Ensurer", func() {
 	var (
 		ctx = context.TODO()
 
-		ctrl *gomock.Controller
-
+		ctrl    *gomock.Controller
 		ensurer genericmutator.Ensurer
 
 		dummyContext = gcontext.NewGardenContext(nil, nil)
@@ -70,11 +76,43 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
+
+		controlPlaneConfig = &apismetal.ControlPlaneConfig{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       "ControlPlaneConfig",
+			},
+			HostnamePolicy: apismetal.HostnamePolicyServer,
+		}
+		controlPlaneConfigRaw, _  = json.Marshal(controlPlaneConfig)
+		eContextK8sServerHostName = gcontext.NewInternalGardenContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Provider: gardencorev1beta1.Provider{
+							ControlPlaneConfig: &apiruntime.RawExtension{Raw: controlPlaneConfigRaw},
+						},
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.26.0",
+						},
+					},
+				},
+				Seed: &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							metal.LocalMetalAPIAnnotation: "true",
+						},
+					},
+				},
+			},
+		)
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		ensurer = NewEnsurer(logger, false)
+		scheme := runtime.NewScheme()
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+		ensurer = controlplane.NewEnsurer(logr.Discard(), scheme)
 	})
 
 	AfterEach(func() {
@@ -237,89 +275,92 @@ var _ = Describe("Ensurer", func() {
 
 	Describe("#EnsureMachineControllerManagerDeployment", func() {
 		var (
-			ensurer    genericmutator.Ensurer
 			deployment *appsv1.Deployment
 		)
 
 		BeforeEach(func() {
 			deployment = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}}
+			DeferCleanup(testutils.WithVar(&controlplane.ImageVector, imagevectorutils.ImageVector{{
+				Name:       "machine-controller-manager-provider-ironcore-metal",
+				Repository: ptr.To("foo"),
+				Tag:        ptr.To[string]("bar"),
+			}}))
 		})
 
-		Context("when gardenlet manages MCM", func() {
-			BeforeEach(func() {
-				ensurer = NewEnsurer(logger, true)
-				DeferCleanup(testutils.WithVar(&ImageVector, imagevectorutils.ImageVector{{
-					Name:       "machine-controller-manager-provider-ironcore-metal",
-					Repository: ptr.To("foo"),
-					Tag:        ptr.To[string]("bar"),
-				}}))
-			})
-
-			It("should inject the sidecar container", func() {
-				Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
-				Expect(ensurer.EnsureMachineControllerManagerDeployment(ctx, eContextK8s, deployment, nil)).To(Succeed())
-				Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(metal.AllowEgressToIstioIngressLabel, "allowed"))
-				Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(corev1.Container{
-					Name:            "machine-controller-manager-provider-ironcore-metal",
-					Image:           "foo:bar",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Args: []string{
-						"--control-kubeconfig=inClusterConfig",
-						"--machine-creation-timeout=20m",
-						"--machine-drain-timeout=2h",
-						"--machine-health-timeout=10m",
-						"--machine-safety-apiserver-statuscheck-timeout=30s",
-						"--machine-safety-apiserver-statuscheck-period=1m",
-						"--machine-safety-orphan-vms-period=30m",
-						"--namespace=" + namespace,
-						"--port=" + strconv.Itoa(portProviderMetrics),
-						"--target-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
-						"--v=3",
-						"--metal-kubeconfig=/etc/metal/kubeconfig",
-					},
-					LivenessProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/healthz",
-								Port:   intstr.FromInt32(portProviderMetrics),
-								Scheme: corev1.URISchemeHTTP,
-							},
+		It("should inject the sidecar container", func() {
+			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
+			Expect(ensurer.EnsureMachineControllerManagerDeployment(ctx, eContextK8s, deployment, nil)).To(Succeed())
+			Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(metal.AllowEgressToIstioIngressLabel, "allowed"))
+			Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(corev1.Container{
+				Name:            "machine-controller-manager-provider-ironcore-metal",
+				Image:           "foo:bar",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Args: []string{
+					"--control-kubeconfig=inClusterConfig",
+					"--machine-creation-timeout=20m",
+					"--machine-drain-timeout=2h",
+					"--machine-health-timeout=10m",
+					"--machine-safety-apiserver-statuscheck-timeout=30s",
+					"--machine-safety-apiserver-statuscheck-period=1m",
+					"--machine-safety-orphan-vms-period=30m",
+					"--namespace=" + namespace,
+					"--port=" + strconv.Itoa(portProviderMetrics),
+					"--target-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+					"--v=3",
+					"--metal-kubeconfig=/etc/metal/kubeconfig",
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/healthz",
+							Port:   intstr.FromInt32(portProviderMetrics),
+							Scheme: corev1.URISchemeHTTP,
 						},
-						InitialDelaySeconds: 30,
-						TimeoutSeconds:      5,
-						PeriodSeconds:       10,
-						SuccessThreshold:    1,
-						FailureThreshold:    3,
 					},
-					Ports: []corev1.ContainerPort{{
-						Name:          portNameProviderMetrics,
-						ContainerPort: portProviderMetrics,
-						Protocol:      corev1.ProtocolTCP,
-					}},
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      "kubeconfig",
-						MountPath: gardenerutils.VolumeMountPathGenericKubeconfig,
+					InitialDelaySeconds: 30,
+					TimeoutSeconds:      5,
+					PeriodSeconds:       10,
+					SuccessThreshold:    1,
+					FailureThreshold:    3,
+				},
+				Ports: []corev1.ContainerPort{{
+					Name:          portNameProviderMetrics,
+					ContainerPort: portProviderMetrics,
+					Protocol:      corev1.ProtocolTCP,
+				}},
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "kubeconfig",
+					MountPath: gardenerutils.VolumeMountPathGenericKubeconfig,
+					ReadOnly:  true,
+				},
+					{
+						Name:      "cloudprovider",
+						MountPath: "/etc/metal",
 						ReadOnly:  true,
 					},
-						{
-							Name:      "cloudprovider",
-							MountPath: "/etc/metal",
-							ReadOnly:  true,
-						},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: ptr.To(false),
+				},
+			}))
+			Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
+				Name: "cloudprovider",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "cloudprovider",
 					},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-					},
-				}))
-				Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
-					Name: "cloudprovider",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: "cloudprovider",
-						},
-					},
-				}))
-			})
+				},
+			}))
+		})
+
+		It("should add node name policy flag to the sidecar container", func() {
+			Expect(deployment.Spec.Template.Spec.Containers).To(BeEmpty())
+			Expect(ensurer.EnsureMachineControllerManagerDeployment(ctx, eContextK8sServerHostName, deployment, nil)).To(Succeed())
+			Expect(deployment.Spec.Template.Spec.Containers).To(
+				ContainElement(
+					HaveField("Args", ContainElement("--use-server-name-as-node-name=true")),
+				),
+			)
 		})
 	})
 })


### PR DESCRIPTION
# Proposed Changes

Extend the `Controlplane` provider configuration to allow to set the `NodeNamePolicy` for a `Shoot` cluster. Supported values are `Server`. If that field is set, the MCM gets an extra `arg` to use the `Server` name as a `Node` name instead of using the `ServerClaim` name.

If this field is not set, `ServerClaim` name will be used (default behaviour).

This solution should be future proof in case we add a `ServerClaim.Spec.Hostname` field for custom hostnames.

/ref https://github.com/ironcore-dev/machine-controller-manager-provider-ironcore-metal/pull/103