### PR TITLE
[GEP-26] Enable validation of `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef`

### DIFF
--- a/pkg/admission/validator/backupbucket.go
+++ b/pkg/admission/validator/backupbucket.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ironcoremetalvalidation "github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/apis/metal/validation"
+)
+
+// backupBucketValidator validates create and update operations on BackupBucket resources,
+type backupBucketValidator struct{}
+
+// NewBackupBucketValidator returns a new instance of backupBucket validator.
+func NewBackupBucketValidator() extensionswebhook.Validator {
+	return &backupBucketValidator{}
+}
+
+// Validate validates the BackupBucket resource during create or update operations.
+func (s *backupBucketValidator) Validate(_ context.Context, newObj, _ client.Object) error {
+	backupBucket, ok := newObj.(*gardencore.BackupBucket)
+	if !ok {
+		return fmt.Errorf("wrong object type %T for object", newObj)
+	}
+
+	return s.validateBackupBucket(backupBucket).ToAggregate()
+}
+
+// validateBackupBucket validates the BackupBucket object.
+func (b *backupBucketValidator) validateBackupBucket(backupBucket *gardencore.BackupBucket) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, ironcoremetalvalidation.ValidateBackupBucketCredentialsRef(backupBucket.Spec.CredentialsRef, field.NewPath("spec", "credentialsRef"))...)
+
+	return allErrs
+}

--- a/pkg/admission/validator/backupbucket_test.go
+++ b/pkg/admission/validator/backupbucket_test.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/admission/validator"
+)
+
+var _ = Describe("BackupBucket Validator", func() {
+	Describe("#Validate", func() {
+		var (
+			ctx            context.Context
+			credentialsRef *corev1.ObjectReference
+
+			backupBucketValidator extensionswebhook.Validator
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+			credentialsRef = &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Name:       "backup-credentials",
+				Namespace:  "garden",
+			}
+
+			backupBucketValidator = validator.NewBackupBucketValidator()
+		})
+
+		It("should return err when obj is not a gardencore.BackupBucket", func() {
+			err := backupBucketValidator.Validate(ctx, &corev1.Secret{}, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("wrong object type *v1.Secret for object"))
+		})
+
+		It("should succeed when BackupBucket is created with valid spec", func() {
+			backupBucket := &gardencore.BackupBucket{
+				Spec: gardencore.BackupBucketSpec{
+					CredentialsRef: credentialsRef,
+				},
+			}
+
+			Expect(backupBucketValidator.Validate(ctx, backupBucket, nil)).To(Succeed())
+		})
+	})
+})

--- a/pkg/admission/validator/seed.go
+++ b/pkg/admission/validator/seed.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ironcoremetalvalidation "github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/apis/metal/validation"
+)
+
+// seedValidator validates create and update operations on seed resources,
+type seedValidator struct{}
+
+// NewSeedValidator returns a new instance of seed validator.
+func NewSeedValidator() extensionswebhook.Validator {
+	return &seedValidator{}
+}
+
+// Validate validates the seed resource during create or update operations.
+func (s *seedValidator) Validate(_ context.Context, newObj, _ client.Object) error {
+	seed, ok := newObj.(*gardencore.Seed)
+	if !ok {
+		return fmt.Errorf("wrong object type %T for object", newObj)
+	}
+
+	return s.validateSeed(seed).ToAggregate()
+}
+
+// validateSeed validates the seed object.
+func (b *seedValidator) validateSeed(seed *gardencore.Seed) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if seed.Spec.Backup != nil {
+		allErrs = append(allErrs, ironcoremetalvalidation.ValidateBackupBucketCredentialsRef(seed.Spec.Backup.CredentialsRef, field.NewPath("spec", "backup", "credentialsRef"))...)
+	}
+	return allErrs
+}

--- a/pkg/admission/validator/seed_test.go
+++ b/pkg/admission/validator/seed_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pkg/admission/validator"
+)
+
+var _ = Describe("Seed Validator", func() {
+	Describe("#Validate", func() {
+		var (
+			ctx           context.Context
+			seedValidator extensionswebhook.Validator
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+
+			seedValidator = validator.NewSeedValidator()
+		})
+
+		It("should return err when obj is not a gardencore.Seed", func() {
+			Expect(seedValidator.Validate(ctx, &corev1.Secret{}, nil)).To(MatchError("wrong object type *v1.Secret for object"))
+		})
+
+		It("should succeed to create seed when backup is unset", func() {
+			seed := &gardencore.Seed{
+				Spec: gardencore.SeedSpec{
+					Backup: nil,
+				},
+			}
+
+			Expect(seedValidator.Validate(ctx, seed, nil)).To(Succeed())
+		})
+	})
+})

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -37,6 +37,8 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			NewCloudProfileValidator(mgr):           {{Obj: &core.CloudProfile{}}},
 			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
 			NewSecretBindingValidator(mgr):          {{Obj: &core.SecretBinding{}}},
+			NewSeedValidator():                      {{Obj: &core.Seed{}}},
+			NewBackupBucketValidator():              {{Obj: &core.BackupBucket{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{

--- a/pkg/apis/metal/validation/backupbucket.go
+++ b/pkg/apis/metal/validation/backupbucket.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var (
+	secretGVK = corev1.SchemeGroupVersion.WithKind("Secret")
+
+	allowedGVKs = sets.New(secretGVK)
+	validGVKs   = []string{secretGVK.String()}
+)
+
+// ValidateBackupBucketCredentialsRef validates credentialsRef is set to supported kind of credentials.
+func ValidateBackupBucketCredentialsRef(credentialsRef *corev1.ObjectReference, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if credentialsRef == nil {
+		return append(allErrs, field.Required(fldPath, "must be set"))
+	}
+
+	if !allowedGVKs.Has(credentialsRef.GroupVersionKind()) {
+		allErrs = append(allErrs, field.NotSupported(fldPath, credentialsRef.String(), validGVKs))
+	}
+
+	return allErrs
+}

--- a/pkg/apis/metal/validation/backupbucket_test.go
+++ b/pkg/apis/metal/validation/backupbucket_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var _ = Describe("BackupBucket", func() {
+	Describe("ValidateBackupBucketCredentialsRef", func() {
+		var fldPath *field.Path
+
+		BeforeEach(func() {
+			fldPath = field.NewPath("spec", "credentialsRef")
+		})
+
+		It("should forbid nil credentialsRef", func() {
+			errs := ValidateBackupBucketCredentialsRef(nil, fldPath)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.credentialsRef"),
+				"Detail": Equal("must be set"),
+			}))))
+		})
+
+		It("should forbid v1.ConfigMap credentials", func() {
+			credsRef := &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "my-creds",
+				Namespace:  "my-namespace",
+			}
+			errs := ValidateBackupBucketCredentialsRef(credsRef, fldPath)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeNotSupported),
+				"Field":  Equal("spec.credentialsRef"),
+				"Detail": Equal("supported values: \"/v1, Kind=Secret\""),
+			}))))
+		})
+
+		It("should forbid security.gardener.cloud/v1alpha1.WorkloadIdentity credentials", func() {
+			credsRef := &corev1.ObjectReference{
+				APIVersion: "security.gardener.cloud/v1alpha1",
+				Kind:       "WorkloadIdentity",
+				Name:       "my-creds",
+				Namespace:  "my-namespace",
+			}
+			errs := ValidateBackupBucketCredentialsRef(credsRef, fldPath)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeNotSupported),
+				"Field":  Equal("spec.credentialsRef"),
+				"Detail": Equal("supported values: \"/v1, Kind=Secret\""),
+			}))))
+		})
+
+		It("should allow v1.Secret credentials", func() {
+			credsRef := &corev1.ObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Name:       "my-creds",
+				Namespace:  "my-namespace",
+			}
+			errs := ValidateBackupBucketCredentialsRef(credsRef, fldPath)
+			Expect(errs).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement

**What this PR does / why we need it**:
Enable validation of `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef`

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
To be rebased on latest `main` after https://github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pull/239 is merged

cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Admission controller now allows `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef` to refer only to credentials of type `v1.Secret`.
```
