### PR TITLE
Specify Priority on MachineDeployment

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -90,6 +90,7 @@ func (w *workerDelegate) GenerateMachineDeployments(ctx context.Context) (worker
 				Annotations:          pool.Annotations,
 				Taints:               pool.Taints,
 				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
+				Priority:             ptr.To(int32(1)),
 			})
 		}
 	}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -162,6 +162,7 @@ var _ = Describe("Machines", func() {
 				Annotations:          pool.Annotations,
 				Taints:               pool.Taints,
 				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
+				Priority:             ptr.To(int32(1)),
 			},
 			worker.MachineDeployment{
 				Name:       deploymentName2,
@@ -182,6 +183,7 @@ var _ = Describe("Machines", func() {
 				Annotations:          pool.Annotations,
 				Taints:               pool.Taints,
 				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
+				Priority:             ptr.To(int32(1)),
 			},
 		}))
 	})


### PR DESCRIPTION
# Proposed Changes

- Specifies `Priority` on MachineDeployment since its promoted to `required` field with [Gardener v1.128](https://github.com/gardener/gardener/releases/tag/v1.127.0)

Fixes #
https://github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/issues/257