### PR TITLE
[GEP-28] Use technicalID from `Cluster` instead of `Worker.Namespace`

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -62,7 +62,7 @@ func (w *workerDelegate) GenerateMachineDeployments(ctx context.Context) (worker
 				return nil, err
 			}
 			var (
-				deploymentName = fmt.Sprintf("%s-%s-z%d", w.worker.Namespace, pool.Name, zoneIndex+1)
+				deploymentName = fmt.Sprintf("%s-%s-z%d", w.cluster.Shoot.Status.TechnicalID, pool.Name, zoneIndex+1)
 				className      = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 			)
 			zoneIdx := int32(zoneIndex)
@@ -153,7 +153,7 @@ func (w *workerDelegate) generateMachineClassAndSecrets(ctx context.Context) ([]
 
 		for zoneIndex, zone := range pool.Zones {
 			var (
-				deploymentName = fmt.Sprintf("%s-%s-z%d", w.worker.Namespace, pool.Name, zoneIndex+1)
+				deploymentName = fmt.Sprintf("%s-%s-z%d", w.cluster.Shoot.Status.TechnicalID, pool.Name, zoneIndex+1)
 				className      = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 			)
 
@@ -172,7 +172,7 @@ func (w *workerDelegate) generateMachineClassAndSecrets(ctx context.Context) ([]
 			}
 
 			machineClassProviderSpec[metal.LabelsFieldName] = map[string]string{
-				metal.ClusterNameLabel: w.cluster.ObjectMeta.Name,
+				metal.ClusterNameLabel: w.cluster.Shoot.Status.TechnicalID,
 			}
 
 			machineClassProviderSpecJSON, err := json.Marshal(machineClassProviderSpec)

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Machines", func() {
 			// TODO: Fix machine pool hashing
 			workerPoolHash, err := worker.WorkerPoolHash(pool, testCluster, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
-			deploymentName = fmt.Sprintf("%s-%s-z%d", ns.Name, pool.Name, 1)
+			deploymentName = fmt.Sprintf("%s-%s-z%d", technicalID, pool.Name, 1)
 			className = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 			machineClass = &machinecontrollerv1alpha1.MachineClass{
 				ObjectMeta: metav1.ObjectMeta{
@@ -80,7 +80,7 @@ var _ = Describe("Machines", func() {
 			machineClassProviderSpec := map[string]any{
 				"image": "registry/my-os",
 				"labels": map[string]any{
-					metal.ClusterNameLabel: testCluster.ObjectMeta.Name,
+					metal.ClusterNameLabel: technicalID,
 				},
 				metal.ServerLabelsFieldName: map[string]string{
 					"foo":  "bar",
@@ -129,8 +129,8 @@ var _ = Describe("Machines", func() {
 		workerPoolHash, err := worker.WorkerPoolHash(pool, testCluster, nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		var (
-			deploymentName1 = fmt.Sprintf("%s-%s-z%d", w.Namespace, pool.Name, 1)
-			deploymentName2 = fmt.Sprintf("%s-%s-z%d", w.Namespace, pool.Name, 2)
+			deploymentName1 = fmt.Sprintf("%s-%s-z%d", technicalID, pool.Name, 1)
+			deploymentName2 = fmt.Sprintf("%s-%s-z%d", technicalID, pool.Name, 2)
 			className1      = fmt.Sprintf("%s-%s", deploymentName1, workerPoolHash)
 			className2      = fmt.Sprintf("%s-%s", deploymentName2, workerPoolHash)
 		)

--- a/pkg/controller/worker/suite_test.go
+++ b/pkg/controller/worker/suite_test.go
@@ -56,6 +56,8 @@ var (
 
 // global Gardener resources used by delegates
 var (
+	technicalID = "shoot--test--cluster"
+
 	shootVersionMajorMinor = "1.2"
 	shootVersion           = shootVersionMajorMinor + ".3"
 	userDataSecretName     = "userdata-secret-name"
@@ -288,6 +290,9 @@ func SetupTest() (*corev1.Namespace, *gardener.ChartApplier) {
 							Raw: []byte("{}"),
 						},
 					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					TechnicalID: technicalID,
 				},
 			},
 		}


### PR DESCRIPTION
# Proposed Changes

To support self-hosted shoots with managed infrastructure, the `Worker` controller/delegate needs to use the technical ID from `Cluster.shoot.status.technicalID` for prefixing the names of machine-related objects. The `Worker` namespace is `kube-system` for self-hosted shoots.
This PR is similar to [gardener/gardener@`22f4295` (#13485)](https://github.com/gardener/gardener/pull/13485/commits/22f429593ba87fb08c3a37fb0ce3c1da914c0f21).

Part of https://github.com/gardener/gardener/pull/13485