### PR TITLE
Fix integer formatting for bgp as numbers

### DIFF
--- a/charts/internal/shoot-system-components/charts/calico-bgp/templates/bgppeer.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-bgp/templates/bgppeer.yaml
@@ -5,9 +5,9 @@
 apiVersion: crd.projectcalico.org/v1
 kind: BGPPeer
 metadata:
-  name: bgppeer-{{ $peer.asNumber }}-{{ $peer.peerIP }}
+  name: bgppeer-{{ printf "%.0f" $peer.asNumber }}-{{ $peer.peerIP }}
 spec:
-  asNumber: {{ $peer.asNumber }}
+  asNumber: {{ printf "%.0f" $peer.asNumber }}
   {{- if $peer.nodeSelector }}
   nodeSelector: {{ $peer.nodeSelector }}
   {{- end }}


### PR DESCRIPTION
Fixes the following if converted dotted AS are used (e.g. `4269539332`)
```
# Source: calico-bgp/templates/bgppeer.yaml
apiVersion: crd.projectcalico.org/v1
kind: BGPPeer
metadata:
  name: bgppeer-4.269539332e+09-192.168.1.1
spec:
  asNumber: 4.269539332e+09
  peerIP: 192.168.1.1
```