### PR TITLE
Add provider config to worker pool v2 hash scheme

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -235,8 +235,12 @@ func (w *workerDelegate) generateMachineClassAndSecrets(ctx context.Context) ([]
 }
 
 func (w *workerDelegate) generateHashForWorkerPool(pool v1alpha1.WorkerPool) (string, error) {
+	providerConfig := ""
+	if pool.ProviderConfig != nil {
+		providerConfig = string(pool.ProviderConfig.Raw)
+	}
 	// Generate the worker pool hash.
-	return worker.WorkerPoolHash(pool, w.cluster, nil, nil, nil)
+	return worker.WorkerPoolHash(pool, w.cluster, nil, []string{providerConfig}, []string{providerConfig})
 }
 
 func (w *workerDelegate) getServerLabelsForMachine(machineType string, workerConfig *metalv1alpha1.WorkerConfig) (map[string]string, error) {


### PR DESCRIPTION
The v1 scheme considered the providerConfig implicitly, which the v2 scheme no longer does.
On recent Gardener versions this means that ignition changes no longer triggered a machine rollout.