### PR TITLE
Set PoolName on generated MachineDeployments

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -81,6 +81,7 @@ func (w *workerDelegate) GenerateMachineDeployments(ctx context.Context) (worker
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
 				Name:                 deploymentName,
+				PoolName:             pool.Name,
 				ClassName:            className,
 				SecretName:           className,
 				Minimum:              worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -148,6 +148,7 @@ var _ = Describe("Machines", func() {
 		Expect(machineDeployments).To(Equal(worker.MachineDeployments{
 			worker.MachineDeployment{
 				Name:       deploymentName1,
+				PoolName:   pool.Name,
 				ClassName:  className1,
 				SecretName: className1,
 				Minimum:    worker.DistributeOverZones(0, pool.Minimum, 2),
@@ -169,6 +170,7 @@ var _ = Describe("Machines", func() {
 			},
 			worker.MachineDeployment{
 				Name:       deploymentName2,
+				PoolName:   pool.Name,
 				ClassName:  className2,
 				SecretName: className2,
 				Minimum:    worker.DistributeOverZones(1, pool.Minimum, 2),

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -192,6 +192,20 @@ var _ = Describe("Machines", func() {
 			},
 		}))
 	})
+
+	It("should set PoolName on each MachineDeployment to the worker pool name", func(ctx SpecContext) {
+		decoder := serializer.NewCodecFactory(k8sClient.Scheme(), serializer.EnableStrict).UniversalDecoder()
+		workerDelegate, err := NewWorkerDelegate(k8sClient, decoder, k8sClient.Scheme(), "", w, testCluster)
+		Expect(err).NotTo(HaveOccurred())
+
+		machineDeployments, err := workerDelegate.GenerateMachineDeployments(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, md := range machineDeployments {
+			Expect(md.PoolName).ToNot(BeEmpty(), "PoolName must not be empty for deployment %s", md.Name)
+			Expect(md.PoolName).To(Equal(pool.Name), "PoolName must match the worker pool name for deployment %s", md.Name)
+		}
+	})
 })
 
 func encodeMap(m map[string]any) []byte {


### PR DESCRIPTION
## Summary

Sets the `PoolName` field on `worker.MachineDeployment` structs generated by `GenerateMachineDeployments`. Without this, the generic actuator sets the `worker.gardener.cloud/pool` label to an empty string, causing the gardenlet rollout-workers operation to fail.

## Root Cause

The `MachineDeployment.PoolName` field was never populated. The generic actuator in gardener uses this field to set:

```go
metav1.SetMetaDataLabel(&machineDeployment.ObjectMeta, v1beta1constants.LabelWorkerPool, deployment.PoolName)
```

## Fix

Set `PoolName: pool.Name` when constructing `worker.MachineDeployment` in the worker delegate.

Closes https://github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/issues/312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine deployments now automatically include a worker pool name field, enabling clear identification of which pool each deployment belongs to and improving deployment management visibility.

* **Tests**
  * Expanded test coverage to ensure pool names are correctly assigned to all generated machine deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/gardener-extension-provider-ironcore-metal/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->