### PR TITLE
Don't set patch version in go language version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ironcore-dev/gardener-extension-provider-ironcore-metal
 
-go 1.26.2
+go 1.26.0
+
+toolchain go1.26.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
To bump the toolchain the toolchain directive should be used.

This reduces development friction as consumers of the library do not get forcefully their go language version bumped which causes issues with other tooling that parse that version or refuse work if eg.: the go version is not available in all distribution ways, yet, and automatically downloading other toolchains is not allowed for compliance reasons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go runtime toolchain to the latest version for enhanced stability, security, and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->