### PR TITLE
Fix WorkloadIdentity token injection for MCM & CCM

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -76,11 +76,6 @@ spec:
         - mountPath: /etc/metal
           name: cloudprovider
           readOnly: true
-{{- if .Values.workloadIdentity.enabled }}
-        - mountPath: /var/run/secrets/gardener.cloud/workload-identity
-          name: workload-identity
-          readOnly: true
-{{- end }}
       - name: metal-machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
         imagePullPolicy: IfNotPresent
@@ -116,18 +111,18 @@ spec:
           readOnly: true
       volumes:
       - name: cloudprovider
-        secret:
-          secretName: cloudprovider
-{{- if .Values.workloadIdentity.enabled }}
-      - name: workload-identity
         projected:
           defaultMode: 420
           sources:
-          - serviceAccountToken:
-              path: token
-              expirationSeconds: 3600
-              audience: metal-api
-{{- end }}
+          - secret:
+              name: cloudprovider
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              {{- if .Values.workloadIdentity.enabled }}
+              - key: token
+                path: token
+              {{- end }}
       - name: kubeconfig
         projected:
           defaultMode: 420

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -91,11 +91,6 @@ spec:
               mountPath: /etc/kubernetes/cloudprovider
             - name: cloudprovider
               mountPath: /etc/metal
-{{- if .Values.workloadIdentity.enabled }}
-            - mountPath: /var/run/secrets/gardener.cloud/workload-identity
-              name: workload-identity
-              readOnly: true
-{{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -124,15 +119,15 @@ spec:
           configMap:
             name: cloud-provider-config
         - name: cloudprovider
-          secret:
-            secretName: cloudprovider
-{{- if .Values.workloadIdentity.enabled }}
-        - name: workload-identity
           projected:
             defaultMode: 420
             sources:
-            - serviceAccountToken:
-                path: token
-                expirationSeconds: 3600
-                audience: metal-api
-{{- end }}
+            - secret:
+                name: cloudprovider
+                items:
+                - key: kubeconfig
+                  path: kubeconfig
+                {{- if .Values.workloadIdentity.enabled }}
+                - key: token
+                  path: token
+                {{- end }}

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -84,7 +84,7 @@ func (e *ensurer) ensureWorkloadIdentitySecret(
 		AuthInfos: []clientcmdv1.NamedAuthInfo{{
 			Name: "workload-identity",
 			AuthInfo: clientcmdv1.AuthInfo{
-				TokenFile: "/var/run/secrets/gardener.cloud/workload-identity/token",
+				TokenFile: "/etc/metal/token",
 			},
 		}},
 		Contexts: []clientcmdv1.NamedContext{{

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -241,7 +241,7 @@ var _ = Describe("Ensurer (workload identity)", func() {
 			Expect(config.Clusters[config.CurrentContext].Server).To(Equal("https://localhost"))
 			Expect(config.Clusters[config.CurrentContext].CertificateAuthorityData).To(Equal([]byte("abcd1234")))
 			Expect(config.AuthInfos["workload-identity"].Token).To(BeEmpty())
-			Expect(config.AuthInfos["workload-identity"].TokenFile).To(Equal("/var/run/secrets/gardener.cloud/workload-identity/token"))
+			Expect(config.AuthInfos["workload-identity"].TokenFile).To(Equal("/etc/metal/token"))
 			Expect(config.Contexts[config.CurrentContext].Namespace).To(Equal("my-namespace"))
 		})
 


### PR DESCRIPTION
The previous implementation used a local `serviceAccountToken `volume, which caused the Seed cluster's Kubelet to generate the token. Since the Metal API `AuthConfig` strictly trusts the Garden cluster's Workload Identity issuer, this Seed-signed token was rejected with a `401 Unauthorized` error
By removing the conflicting local volume and projecting the secret directly, the controllers now should correctly consume the Garden-signed token